### PR TITLE
Fix: commad-helpers creates NEW ConfigManager with defaults

### DIFF
--- a/src/utils/command-helpers.ts
+++ b/src/utils/command-helpers.ts
@@ -15,7 +15,7 @@ export function initializeServices(includeOrderHistory = false): ServiceContaine
   return {
     analyzer,
     executor: new TradingExecutor(),
-    riskManager: new RiskManager(),
+    riskManager: new RiskManager(analyzer.getConfigManager()),
     // 使用 analyzer 内部的 orderHistoryManager 实例,确保一致性
     ...(includeOrderHistory && { orderHistoryManager: analyzer.getOrderHistoryManager() })
   };


### PR DESCRIPTION
Even though I set
PRICE_TOLERANCE=2.0
in the environment variables, the fault tolerance still defaulted to 1%.

It seems that RiskManager is being initialized with its default values instead of using the configured ones.